### PR TITLE
fix: declare @exodus/walletconnect-environment as a runtime dependency

### DIFF
--- a/crypto/crypto/package.json
+++ b/crypto/crypto/package.json
@@ -39,7 +39,8 @@
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'"
   },
   "dependencies": {
-    "@exodus/crypto": "^1.0.0-rc.20"
+    "@exodus/crypto": "^1.0.0-rc.20",
+    "@exodus/walletconnect-environment": "^1.0.0-exodus.0"
   },
   "devDependencies": {
     "@peculiar/webcrypto": "^1.1.7",


### PR DESCRIPTION
## What
Declares `@exodus/walletconnect-environment` as a runtime `dependency` of `@exodus/walletconnect-crypto`.

## Why — phantom dependency
`crypto/crypto/src/helpers/env.ts` does `export * from "@exodus/walletconnect-environment"` — a runtime re-export — but `@exodus/walletconnect-environment` was not in `dependencies` (only `@exodus/crypto` was). That makes it a phantom dependency: it resolves today via hoisting, but under pnpm `nodeLinker: isolated` / `hoist: false` the import would fail.

Surfaced while auditing phantom deps for the exodus-mobile `nodeLinker: isolated` effort (ExodusMovement/exodus#42439). The sibling package `@exodus/walletconnect-jsonrpc-utils` already declares `@exodus/walletconnect-environment: ^1.0.0-exodus.0`.

## Change
- Add `"@exodus/walletconnect-environment": "^1.0.0-exodus.0"` to `@exodus/walletconnect-crypto` dependencies (matches the sibling convention).

## Test plan
- [x] `src/helpers/env.ts` `export * from "@exodus/walletconnect-environment"` (runtime re-export) — previously undeclared
- [x] Declared range `^1.0.0-exodus.0` resolves to a published env (`1.0.0-exodus.0`); mirrors sibling `@exodus/walletconnect-jsonrpc-utils`
